### PR TITLE
fix: course title not set when creating a reminder + unique key for timetable

### DIFF
--- a/app/src/main/java/com/dscvit/vitty/model/PeriodDetails.kt
+++ b/app/src/main/java/com/dscvit/vitty/model/PeriodDetails.kt
@@ -2,9 +2,11 @@ package com.dscvit.vitty.model
 
 import com.google.firebase.Timestamp
 import java.util.Date
+import java.util.UUID
 
 data class PeriodDetails(
 //    var courseType: String = "",
+    val id: String = UUID.randomUUID().toString(),
     var courseCode: String = "",
     var courseName: String = "",
     var startTime: Timestamp = Timestamp(Date()),

--- a/app/src/main/java/com/dscvit/vitty/ui/academics/AcademicsScreenContent.kt
+++ b/app/src/main/java/com/dscvit/vitty/ui/academics/AcademicsScreenContent.kt
@@ -172,6 +172,9 @@ fun AcademicsScreenContent(
                     alertDaysBefore,
                     attachmentUrl,
                     ->
+                    coursePageViewModel.setCourseId(selectedCourseForReminder!!.code)
+                    coursePageViewModel.setCourseTitle(selectedCourseForReminder!!.title)
+
                     coursePageViewModel.addReminder(
                         title = title,
                         description = description,

--- a/app/src/main/java/com/dscvit/vitty/ui/academics/components/AcademicsScreenComponents.kt
+++ b/app/src/main/java/com/dscvit/vitty/ui/academics/components/AcademicsScreenComponents.kt
@@ -470,7 +470,6 @@ fun CourseCard(
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun RemindersContent(
     reminders: List<Reminder>,

--- a/app/src/main/java/com/dscvit/vitty/ui/connect/CircleMemberDetailScreenContent.kt
+++ b/app/src/main/java/com/dscvit/vitty/ui/connect/CircleMemberDetailScreenContent.kt
@@ -398,7 +398,7 @@ private fun DayScheduleContent(
         ) {
             items(
                 items = periods,
-                key = { period -> "${period.courseCode}_${period.slot}" },
+                key = { period -> period.id },
             ) { period ->
                 CircleMemberPeriodCard(
                     period = period,

--- a/app/src/main/java/com/dscvit/vitty/ui/connect/FriendDetailScreenContent.kt
+++ b/app/src/main/java/com/dscvit/vitty/ui/connect/FriendDetailScreenContent.kt
@@ -772,7 +772,7 @@ private fun DayScheduleContent(
         ) {
             items(
                 items = periods,
-                key = { period -> "${periods.indexOf(period)}${period.startTime}_${period.courseCode}_${period.slot}_${period.endTime}" },
+                key = { period -> period.id },
             ) { period ->
                 FriendPeriodCard(
                     period = period,

--- a/app/src/main/java/com/dscvit/vitty/ui/schedule/ScheduleScreenContent.kt
+++ b/app/src/main/java/com/dscvit/vitty/ui/schedule/ScheduleScreenContent.kt
@@ -410,7 +410,7 @@ private fun DayContent(
         ) {
             items(
                 items = periods,
-                key = { period -> "${periods.indexOf(period)}${period.startTime}_${period.courseCode}_${period.slot}_${period.endTime}" },
+                key = { period -> period.id },
             ) { period ->
                 PeriodCard(
                     period = period,


### PR DESCRIPTION
# Pull Request Type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Purpose
- WHAT is this PR for?
- Fixes course title not being set when creating a reminder
- Fatal Exception: java.lang.IllegalArgumentException
Key "0Timestamp(seconds=1754904600, nanoseconds=0)_BCSE334L_F2_Timestamp(seconds=1754907600, nanoseconds=0)" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.

# Approach
- HOW does this change fulfill the purpose?
- Fixes the bug by setting course ID and title when adding a reminder in AcademicsScreenContent
- Fixes the bug by generating a random UUID for each period

# Does this PR introduce any new bug?
- [ ] Yes
- [x] No
- [ ] Maybe

#### Issue Reference: #63 